### PR TITLE
MAINT: refactor to select sort method later, removing duplicated code paths

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -681,16 +681,20 @@ static PyType_Slot PyArray_StringDType_Slots[] = {
 
 
 /*
- * Wrap the sort loop to acquire/release the string allocator.
+ * Wrap the sort loop to acquire/release the string allocator,
+ * and pick the correct internal implementation.
  */
 int
 stringdtype_wrap_sort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_SortImpl *sort_loop)
+        NpyAuxData *transferdata)
 {
     PyArray_StringDTypeObject *sdescr =
             (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_SortImpl *sort_loop =
+        ((PyArrayMethod_SortParameters *)context->parameters)->flags
+        == NPY_SORT_STABLE ? &npy_mergesort_impl : &npy_quicksort_impl;
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
     int ret = sort_loop(
@@ -732,10 +736,13 @@ int
 stringdtype_wrap_argsort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_ArgSortImpl *argsort_loop)
+        NpyAuxData *transferdata)
 {
     PyArray_StringDTypeObject *sdescr =
             (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_ArgSortImpl *argsort_loop =
+        ((PyArrayMethod_SortParameters *)context->parameters)
+        ->flags == NPY_SORT_STABLE ? &npy_amergesort_impl : &npy_aquicksort_impl;
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
     int ret = argsort_loop(
@@ -743,32 +750,6 @@ stringdtype_wrap_argsort_loop(
             context->descriptors[0]->elsize, &_sort_compare);
     NpyString_release_allocator(allocator);
     return ret;
-}
-
-int
-stringdtype_sort_loop(
-        PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    npy_bool stable = (((PyArrayMethod_SortParameters *)context->parameters)
-                       ->flags == NPY_SORT_STABLE);
-    return stringdtype_wrap_sort_loop(
-            context, data, dimensions, strides, transferdata,
-            stable ? &npy_mergesort_impl : &npy_quicksort_impl);
-}
-
-int
-stringdtype_argsort_loop(
-        PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    npy_bool stable = (((PyArrayMethod_SortParameters *)context->parameters)
-                       ->flags == NPY_SORT_STABLE);
-    return stringdtype_wrap_argsort_loop(
-            context, data, dimensions, strides, transferdata,
-            stable ? &npy_amergesort_impl : &npy_aquicksort_impl);
 }
 
 int
@@ -785,7 +766,7 @@ stringdtype_get_sort_loop(
 
     if ((parameters->flags == NPY_SORT_STABLE)
         || parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_sort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_wrap_sort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");
@@ -808,7 +789,7 @@ stringdtype_get_argsort_loop(
 
     if (parameters->flags == NPY_SORT_STABLE
         || parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_argsort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_wrap_argsort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");


### PR DESCRIPTION
@MaanasArora - I wondered again about `NpyAuxData` and realized I was just making things difficult: we have the context in the loop so there is no reason not just to select the relevant internal function there. It allows removing 4 functions!